### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'zulu'
         cache: gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds for all versions of OpenJDK. 👍🏼 